### PR TITLE
Take advantage of new and improved LMP daemon now with /fab/ endpoint!

### DIFF
--- a/server.cfg
+++ b/server.cfg
@@ -7,8 +7,7 @@ TIMEOUT = 1
 DEBUG = True
 
 LMP_SERVER = 'http://localhost:31179/lmp/'
-ZMETRICS_SERVER = 'http://localhost:31179/'
-FAB_SERVER = 'http://localhost:58580/'
+FAB_SERVER = 'http://localhost:31179/'
 MANIFESTING_SERVER = 'http://localhost:31178/manifesting/'
 
 HTTP_HEADERS = {


### PR DESCRIPTION
1. Remove unused variable ZMETRIX_SERVER.
2. Point FAB_SERVER at lmp daemon by default.