### PR TITLE
Enhancements and fixes for running on SDFlex - round 1

### DIFF
--- a/blueprints/pernode/blueprint.py
+++ b/blueprints/pernode/blueprint.py
@@ -175,18 +175,21 @@ class JPower(Journal):
     def get_power_state(self, node):
         # Get the
         d_proxy = { "http" : None }
-        power = 'n/a'
+        power = 'N/A'
         try:
             header = self.mainapp.config['HTTP_HEADERS']
-            url = self.nodeinfo[node-1]['mfwApiUri'] + '/MgmtService/SoC'
+            url = self.nodeinfo[node-1]['mfwApiUri']
+            if url is None:
+                return power
+            url += '/MgmtService/SoC'
             r = requests.get(url, headers=header, proxies=d_proxy,
                             timeout=self.mainapp.config['TIMEOUT'])
             if r.status_code != requests.codes.ok:
-                return 'N/A'
+                return power
             data=r.json()
             power = data['PowerState']
-        except requests.exceptions.Timeout or requests.exceptions.HTTPConnection:
-            print('Cant get power state of node "%s"' % node)
+        except (requests.exceptions.Timeout, requests.exceptions.HTTPError) as err:
+            print('MP Redfish for node "%s" failed or timed out (%s)' % (node, url))
         except Exception as err: #FIXME
             print('Failed to get power state for node %s! [%s]' % (node, err))
 
@@ -195,9 +198,16 @@ class JPower(Journal):
 
     def get_os_manifest(self, node):
         # Get the os manifest for the node from the manifesting service
-        url = self.mainapp.config['MANIFESTING_SERVER'] + 'api/node/' + str(node)
-        r = requests.get(url, headers=self.mainapp.config['HTTP_HEADERS'],
-                        timeout=self.mainapp.config['TIMEOUT'])
+        url = self.mainapp.config['MANIFESTING_SERVER']
+        if url is None:
+            return 'N/A'
+        url += 'api/node/' + str(node)
+        try:
+            r = requests.get(url, headers=self.mainapp.config['HTTP_HEADERS'],
+                             timeout=self.mainapp.config['TIMEOUT'])
+        except Exception as err:
+            print('Cannot get manifest from %s: %s' % (url, str(err)))
+            return 'N/A'
         if r.status_code != requests.codes.ok:
             return "default"
         data=r.json()
@@ -207,21 +217,18 @@ class JPower(Journal):
 
     def get_books_and_shelves(self, node):
         # Get the active books and shelves from LMP active data
-        active = { 'shelves' : 'n/a', 'books' : 'n/a' }
+        active = { 'shelves' : -1, 'books' : -1 }
         try:
             coord = self.nodeinfo[node-1]['active_coordinate']
-            url = self.mainapp.config['LMP_SERVER'] + 'active' + coord
+            url = self.mainapp.config['LMP_SERVER'] + 'active/' + coord
             r = requests.get(url, headers=self.mainapp.config['HTTP_HEADERS'],
                             timeout=self.mainapp.config['TIMEOUT'])
             if r.status_code != requests.codes.ok:
-                return [0, 0]
+                return active
             data=r.json()
             active = data['active']
         except Exception as err:
             print('Failed to get books and shelves for node %s! [%s]' % (node, err))
-            active['shelves'] = 'n/a'
-            active['books'] = 'n/a'
-
         return active
 
 
@@ -300,7 +307,7 @@ def pernode_api(nodestr=-1):
     try:
         Journal.doThings()
     except Exception as err:
-        print('Things went wrong in "nodes" bp! [%s]' % err)
+        print('Things went wrong in "%s" bp! [%s]' % (Journal.BP.name, err))
         Journal.defaults['Node'] = node
         if nodeindex != -1:
             return make_response(jsonify(Journal.spoofStats(node)), 302)
@@ -326,7 +333,7 @@ def pernode_api(nodestr=-1):
         except requests.exceptions.ConnectionError:
             print('Can not connect to Node "%s" to get stats!' % (node-1))
         except Exception as err:
-            print('Failed to get node stats!' % err)
+            print('Failed to get node stats(A)! [%s]' % err)
 
         return make_response(jsonify(nodeData), 200)
     else:
@@ -337,14 +344,13 @@ def pernode_api(nodestr=-1):
                 nodeData['Node'] = node_index
                 result.append(copy.deepcopy(nodeData))
             except Exception as err:
-                print('Failed to get node stats! [%s]' % err)
+                print('Failed to get node stats(B)! [%s]' % err)
                 print(result)
         return make_response(jsonify( { 'nodes' : result }), 200)
 
 
 
 def getNodeStats(node):
-    global Journal
     nodedata = Journal.defaults
     nodedata['Node'] = node
     nodedata['Power State'] = Journal.get_power_state(node)

--- a/blueprints/pernode/utils.py
+++ b/blueprints/pernode/utils.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+
 import json
 
 
@@ -6,7 +7,7 @@ def hostnameFromTmconfig(path, nodeinfo):
     ''' Parse tmconfig file and extract hostnames and mfwApiUri data for each
     node defined. '''
     tmconfig_json = None
-    # Use data from /etc/tmconfig to get hostname and mfwApiUri 
+    # Use data from /etc/tmconfig to get hostname and mfwApiUri
     with open(path) as json_data:
         tmconfig_json = json.load(json_data)
 
@@ -15,8 +16,9 @@ def hostnameFromTmconfig(path, nodeinfo):
         for enc in rack['enclosures']:
             for node in enc['nodes']:
                 hostname = node['soc']['hostname']
-                mfwApiUri = node['nodeMp']['mfwApiUri']
                 nodeindex = int(hostname[4:])-1
                 nodeinfo[nodeindex]['hostname'] = hostname
+                nodeMp = node.get('nodeMp', None)
+                mfwApiUri = nodeMp['mfwApiUri'] if nodeMp else None
                 nodeinfo[nodeindex]['mfwApiUri'] = mfwApiUri
     return nodeinfo

--- a/matryoshka_api.py
+++ b/matryoshka_api.py
@@ -71,7 +71,7 @@ class MainApp:
                 imported_bp.Journal.register(self)
 
                 self.app.register_blueprint(imported_bp.Journal.BP)
-                print('Regestring bluerpint "%s"...' % imported_bp.Journal.name)
+                print('Registering blueprint "%s"...' % imported_bp.Journal.name)
         except Exception as err:
             raise RuntimeError('Something went wrong while importing blueprints...:\n[ %s ]' % err)
 

--- a/server.cfg
+++ b/server.cfg
@@ -1,21 +1,29 @@
 API_VERSION = 1.0
 HOST = '0.0.0.0'
 PORT = 9099
-#Timeoutout in secondes per each HTTP REQUEST to offshore APIs that this
-#server makes per each endpoint.
+# Timeoutout in seconds per each HTTP REQUEST to offshore APIs that this
+# server makes per each endpoint.
 TIMEOUT = 1
 DEBUG = True
 
+# lmp.py (Librarian Management Protocol) runs alongside the Librarian.
 LMP_SERVER = 'http://localhost:31179/lmp/'
+
+# These values are good for SDFlex and FAME setups.  LMP can provide a
+# helper for the Fabric percentage metric.
 FAB_SERVER = 'http://localhost:31179/'
-MANIFESTING_SERVER = 'http://localhost:31178/manifesting/'
+MANIFESTING_SERVER = None
+
+# These values are good for The Machine MFT.
+# FAB_SERVER = 'http://localhost:58580/'
+# MANIFESTING_SERVER = 'http://localhost:31178/manifesting/'
 
 HTTP_HEADERS = {
     'Accept' : 'Content-Type: application/json; charset=utf-8; version=1.0',
     'Access-Control-Allow-Origin' : '*'
 }
 
-#Allow generating Random data when can't ping offshore API.
+# Allow generating Random data when can't ping offshore API.
 # ALLOW_SPOOF = True
 ALLOW_SPOOF = False
 


### PR DESCRIPTION
1. Typos, cosmetics, and details in error/trace messages
2. Using "None" in the master config file and code that respects it.
3. Better default return values
4. One "coordinate" was missing a / separator.